### PR TITLE
Revert "Fix symlinks of DisProt examples "

### DIFF
--- a/Dataset/examples/0.3-DRAFT_examples/DisProt_jsonld.json
+++ b/Dataset/examples/0.3-DRAFT_examples/DisProt_jsonld.json
@@ -1,1 +1,1 @@
-../../../DataCatalog/examples/0.3-DRAFT/DisProt_jsonld.json
+../../../DataCatalog/examples/0.3/DisProt_jsonld.json

--- a/Protein/examples/0.9-DRAFT/DisProt_jsonld.json
+++ b/Protein/examples/0.9-DRAFT/DisProt_jsonld.json
@@ -1,1 +1,1 @@
-../../../DataRecord/examples/0.2-DRAFT_examples/DisProt_jsonld.json
+../../../DataRecord/examples/0.2-DRAFT/DisProt_jsonld.json

--- a/SequenceAnnotation/examples/0.1-DRAFT/DisProt_jsonld.json
+++ b/SequenceAnnotation/examples/0.1-DRAFT/DisProt_jsonld.json
@@ -1,1 +1,0 @@
-../../../DataRecord/examples/0.2-DRAFT_examples/DisProt_jsonld.json

--- a/SequenceRange/examples/0.1-DRAFT/DisProt_jsonld.json
+++ b/SequenceRange/examples/0.1-DRAFT/DisProt_jsonld.json
@@ -1,1 +1,0 @@
-../../../DataRecord/examples/0.2-DRAFT_examples/DisProt_jsonld.json


### PR DESCRIPTION
Reverts BioSchemas/specifications#420
Despite the information provided by the original submitter regarding the symlinks working inside json, it does not.