### PR TITLE
Add MobiDB examples for DataCatalog and DataRecord

### DIFF
--- a/DataCatalog/examples/0.3-RELEASE/MobiDB_jsonld.json
+++ b/DataCatalog/examples/0.3-RELEASE/MobiDB_jsonld.json
@@ -1,0 +1,98 @@
+{
+  "@context": "http://schema.org/",
+  "@type": "DataCatalog",
+  "@id": "https://mobidb.org/",
+  "dct:conformsTo": "https://bioschemas.org/profiles/DataCatalog/0.3-RELEASE-2019_07_01",
+  "sameAs":"https://registry.identifiers.org/registry/mobidb",
+  "url": "https://mobidb.org/",
+  "identifier": "https://registry.identifiers.org/registry/mobidb",
+  "name": "MobiDB, a database of protein disorder and mobility annotations",
+  "description": "MobiDB is a database of protein disorder and mobility annotations. MobiDB was designed to offer a centralized resource for annotations of intrinsic protein disorder and its function. The database covers different disorder aspects such as disordered regions lacking a fixed three-dimensional structure, linear interacting peptides and dynamic structures",
+  "datePublished": "2019-09",
+  "dateModified": "2020-03",
+  "citation": {
+    "@type": "ScholarlyArticle",
+    "@id": "https://doi.org/10.1093/nar/gkx1071",
+    "name": "MobiDB 3.0: more annotations for intrinsic disorder, conformational diversity and interactions in proteins",
+    "url": "https://doi.org/10.1093/nar/gkx1071",
+    "sameAs": [
+      "https://academic.oup.com/nar/article-lookup/doi/10.1093/nar/gkx1071",
+      "https://www.ncbi.nlm.nih.gov/pubmed/29136219"
+    ]
+  },
+  "keywords": [
+    "IDP",
+    "IDPs",
+    "MobiDB",
+    "intrinsic protein disorder",
+    "intrinsically disordered protein",
+    "intrinsically disordered proteins",
+    "protein annotation",
+    "protein disorder",
+    "protein database"
+  ],
+  "sourceOrganization": [
+    {
+      "@context": "http://schema.org",
+      "@type": "Organization",
+      "@id": "http://protein.bio.unipd.it#O",
+      "dct:conformsTo": "https://bioschemas.org/profiles/Organization/0.2-DRAFT-2019_07_19",
+      "description": "University of Padua, Department of Biomedical Sciences, BioComputing UP laboratory",
+      "name": "University of Padova",
+      "url": "http://protein.bio.unipd.it"
+    }
+  ],
+  "provider": [
+    {
+      "@type": "Person",
+      "@id": "Silvio Tosatto",
+      "name": "Silvio Tosatto",
+      "email": "silvio.tosatto@unipd.it"
+    }
+  ],
+  "encodingFormat": [
+    "text/html",
+    "application/json"
+  ],
+  "license": {
+    "@type": "CreativeWork",
+    "@id": "https://creativecommons.org/licenses/by/4.0/",
+    "name": "Creative Commons CC4 Attribution",
+    "url": "https://creativecommons.org/licenses/by/4.0/"
+  },
+  "dataset": {
+    "@context": "http://schema.org",
+    "@type": "Dataset",
+    "@id": "https://mobidb.org/#2020-03",
+    "dct:conformsTo": "https://bioschemas.org/profiles/Dataset/0.3-RELEASE-2019_06_14",
+    "includedInDataCatalog": {
+      "@id": "https://mobidb.org/"
+    },
+    "url": "https://mobidb.org/",
+    "dateModified": "2020-03",
+    "version": "3.1.0",
+    "name": "MobiDB",
+    "description": "MobiDB is a database of protein disorder and mobility annotations. MobiDB was designed to offer a centralized resource for annotations of intrinsic protein disorder and its function. The database covers different disorder aspects such as disordered regions lacking a fixed three-dimensional structure, linear interacting peptides and dynamic structures.",
+    "identifier": "https://mobidb.org/#2020-03",
+    "keywords": [
+      "IDP",
+      "IDPs",
+      "MobiDB",
+      "intrinsic protein disorder",
+      "intrinsically disordered protein",
+      "intrinsically disordered proteins",
+      "protein annotation",
+      "protein disorder",
+      "protein database"
+    ],
+    "creator": {
+      "@id": "http://protein.bio.unipd.it#O"
+    },
+    "license": {
+      "@type": "CreativeWork",
+      "@id": "https://creativecommons.org/licenses/by/4.0/",
+      "name": "Creative Commons CC4 Attribution",
+      "url": "https://creativecommons.org/licenses/by/4.0/"
+    }
+  }
+}

--- a/DataCatalog/examples/REPEATSDB/RepeatsDB_jsonld.json
+++ b/DataCatalog/examples/REPEATSDB/RepeatsDB_jsonld.json
@@ -1,0 +1,98 @@
+{
+  "@context": "http://schema.org/",
+  "@type": "DataCatalog",
+  "@id": "http://repeatsdb.bio.unipd.it/",
+  "dct:conformsTo": "https://bioschemas.org/profiles/DataCatalog/0.3-RELEASE-2019_07_01", ???
+  "sameAs":"https://registry.identifiers.org/registry/mobidb", ???
+  "url": "http://repeatsdb.bio.unipd.it/",
+  "identifier": "https://registry.identifiers.org/registry/mobidb", ???
+  "name": "RepeatsDB, databse of repeat protein structures",
+  "description": "RepeatsDB features structural annotations for tandem repeat proteins, combining computer-based methods and manual curation. The database provides the position of repeat units, regions and insertions, as well as repeat classification.",
+  "datePublished": "2017-01", 
+  "dateModified": "2020-02", 
+  "citation": {
+    "@type": "ScholarlyArticle",
+    "@id": "https://doi.org/10.1093/nar/gkw1136",
+    "name": "RepeatsDB 2.0: improved annotation, classification, search and visualization of repeat protein structures",
+    "url": "https://doi.org/10.1093/nar/gkw1136",
+    "sameAs": [
+      "https://academic.oup.com/nar/article-lookup/doi/10.1093/nar/gkw1136",
+      "https://academic.oup.com/nar/article/45/D1/D308/2605753"
+    ]
+  },
+  "keywords": [
+    "TR",
+    "TRPs",
+    "RepeatsDB",
+    "tandem repeat proteins",
+    "repeat proteins",
+    "tandem repeat regions",
+    "protein annotation",
+    "protein repeats",
+    "protein database"
+  ],
+  "sourceOrganization": [
+    {
+      "@context": "http://schema.org",
+      "@type": "Organization",
+      "@id": "http://protein.bio.unipd.it#O", ???
+      "dct:conformsTo": "https://bioschemas.org/profiles/Organization/0.2-DRAFT-2019_07_19", ???
+      "description": "University of Padua, Department of Biomedical Sciences, BioComputing UP laboratory",
+      "name": "University of Padova",
+      "url": "http://protein.bio.unipd.it"
+    }
+  ],
+  "provider": [
+    {
+      "@type": "Person",
+      "@id": "Silvio Tosatto",
+      "name": "Silvio Tosatto",
+      "email": "silvio.tosatto@unipd.it"
+    }
+  ],
+  "encodingFormat": [
+    "text/html",
+    "application/json"
+  ],
+  "license": {
+    "@type": "CreativeWork",
+    "@id": "https://creativecommons.org/licenses/by/4.0/",
+    "name": "Creative Commons CC4 Attribution",
+    "url": "https://creativecommons.org/licenses/by/4.0/"
+  },
+  "dataset": {
+    "@context": "http://schema.org",
+    "@type": "Dataset",
+    "@id": "https://mobidb.org/#2020-03",
+    "dct:conformsTo": "https://bioschemas.org/profiles/Dataset/0.3-RELEASE-2019_06_14", ???
+    "includedInDataCatalog": {
+      "@id": "http://repeatsdb.bio.unipd.it/"
+    },
+    "url": "http://repeatsdb.bio.unipd.it/",
+    "dateModified": "2020-02",
+    "version": "2020.02.18",
+    "name": "RepeatsDB",
+    "description": "RepeatsDB features structural annotations for tandem repeat proteins, combining computer-based methods and manual curation. The database provides the position of repeat units, regions and insertions, as well as repeat classification.",
+    "identifier": "https://mobidb.org/#2020-03", ???
+    "keywords": [
+      "TR",
+    "TRPs",
+    "RepeatsDB",
+    "tandem repeat proteins",
+    "repeat proteins",
+    "tandem repeat regions",
+    "protein annotation",
+    "protein repeats",
+    "protein database"
+    ],
+    "creator": {
+      "@id": "http://protein.bio.unipd.it#O" ???
+    },
+    "license": {
+      "@type": "CreativeWork",
+      "@id": "https://creativecommons.org/licenses/by/4.0/",
+      "name": "Creative Commons CC4 Attribution",
+      "url": "https://creativecommons.org/licenses/by/4.0/"
+    }
+  }
+}

--- a/DataRecord/examples/0.2-DRAFT_examples/MobiDB_jsonld.json
+++ b/DataRecord/examples/0.2-DRAFT_examples/MobiDB_jsonld.json
@@ -1,0 +1,46 @@
+{
+  "@context": "http://schema.org",
+  "@type": "DataRecord",
+  "@id": "https://mobidb.org/P0DTC9#DR",
+  "dct:conformsTo": "https://bioschemas.org/profiles/DataRecord/0.2-DRAFT-2019_06_14",
+  "includedInDataset": "https://mobidb.org/#2020-03",
+  "mainEntity": {
+    "@type": "Protein",
+    "@id": "https://mobidb.org/P0DTC9",
+    "dct:conformsTo": "https://bioschemas.org/profiles/Protein/0.11-RELEASE",
+    "identifier": "https://identifiers.org/mobidb:P0DTC9",
+    "sameAs": "http://purl.uniprot.org/uniprot/P0DTC9",
+    "hasBioPolymerSequence": "MSDNGPQNQRNAPRITFGGPSDSTGSNQNGERSGARSKQRRPQGLPNNTASWFTALTQHGKEDLKFPRGQGVPINTNSSPDDQIGYYRRATRRIRGGDGKMKDLSPRWYFYYLGTGPEAGLPYGANKDGIIWVATEGALNTPKDHIGTRNPANNAAIVLQLPQGTTLPKGFYAEGSRGGSQASSRSSSRSRNSSRNSTPGSSRGTSPARMAGNGGDAALALLLLDRLNQLESKMSGKGQQQQGQTVTKKSAAEASKKPRQKRTATKAYNVTQAFGRRGPEQTQGNFGDQELIRQGTDYKHWPQIAQFAPSASAFFGMSRIGMEVTPSGTWLTYTGAIKLDDKDPNFKDQVILLNKHIDAYKTFPPTEPKKDKKKKADETQALPQRQKKQQTVTLLPAADLDDFSKQLQQSMSSADSTQA",
+    "name": "Nucleoprotein",
+    "taxonomicRange": {
+      "@id": "https://identifiers.org/taxonomy:2697049"
+    },
+    "hasSequenceAnnotation": [
+      {
+        "@type": "SequenceAnnotation",
+        "@id": "https://mobidb.org/P0DTC9#disorder-content",
+        "sequenceLocation": {
+          "@type": "SequenceRange",
+          "rangeStart": 1,
+          "rangeEnd": 419
+        },
+        "additionalProperty": {
+          "@type": "PropertyValue",
+          "name": "Term",
+          "value": {
+            "@type": "DefinedTerm",
+            "@id": "https://www.disprot.org/assets/data/idpontology_disprot_8_v0.1.0.owl#DO:00076",
+            "inDefinedTermSet": {
+              "@type": "DefinedTermSet",
+              "@id": "https://www.disprot.org/assets/data/idpontology_disprot_8_v0.1.0.owl",
+              "name": "IDP Ontology"
+            },
+            "termCode": "DO:00076",
+            "name": "Disorder"
+          }
+        },
+        "description": "Consensus disorder content for the protein"
+      }
+    ]
+  }
+}

--- a/DataRecord/examples/0.2-DRAFT_examples/RepeatsDB_jsonld.json
+++ b/DataRecord/examples/0.2-DRAFT_examples/RepeatsDB_jsonld.json
@@ -1,0 +1,71 @@
+{
+  "@context": "http://schema.org",
+  "@type": "DataRecord",
+  "@id": "https://mobidb.org/P0DTC9#DR", ???
+  "dct:conformsTo": "https://bioschemas.org/profiles/DataRecord/0.2-DRAFT-2019_06_14", ???
+  "includedInDataset": "https://mobidb.org/#2020-03", ???
+  "mainEntity": {
+    "@type": "Protein structure",
+    "@id": "https://mobidb.org/1rwrA",
+    "dct:conformsTo": "https://bioschemas.org/profiles/Protein/0.11-RELEASE", ???
+    "identifier": "https://identifiers.org/repeatsdb:1rwrA",
+    "sameAs": "http://purl.uniprot.org/uniprot/1rwrA", ???
+    "hasBioPolymerSequence": "QGLVPQGQTQVLQGGNKVPVVNIADPNSGGVSHNKFQQFNVANPGVVFNNGLTDGVSRIGGALTKNPNLTRQASAILAEVTDTSPSRLAGTLEVYGKGADLIIANPNGISVNGLSTLNASNLTLTTGRPSVNGGRIGLDVQQGTVTIERGGVNATGLGYFDVVARLVKLQGAVSSKQGKPLADIAVVAGANRYDHATRRATPIAAGARGAAAGAYAIDGTAAGAMYGKHITLVSSDSGLGVRQLGSLSSPSAITVSSQGEIALGDATVQRGPLSLKGAGVVSAGKLASGGGAVNVAGGGAV",
+    "name": "Nucleoprotein",
+    "taxonomicRange": {
+      "@id": "https://identifiers.org/taxonomy:2697049"
+    },
+    "hasSequenceAnnotation": [ ???
+      {
+        "@type": "SequenceAnnotation", 
+        "@id": "http://repeatsdb.bio.unipd.it/protein/1rwrA",
+        "sequenceLocation": {
+          "@type": "SequenceRange",
+          "rangeStart": 84,
+          "rangeEnd": 105
+        },
+        "additionalProperty": {
+          "@type": "PropertyValue",
+          "name": "Term",
+          "value": {
+            "@type": "DefinedTerm",
+            "@id": "https://www.disprot.org/assets/data/idpontology_disprot_8_v0.1.0.owl#DO:00076", ???
+            "inDefinedTermSet": {
+              "@type": "DefinedTermSet",
+              "@id": "https://www.disprot.org/assets/data/idpontology_disprot_8_v0.1.0.owl", ???
+              "name": "TR ontology"
+            },
+            "termCode": "DO:00076", ???
+            "name": "Repeat unit"
+          }
+        },
+        "description": "Repeat structure for the protein"
+      },
+      {
+        "@type": "SequenceAnnotation", 
+        "@id": "http://repeatsdb.bio.unipd.it/protein/1rwrA",
+        "sequenceLocation": {
+          "@type": "SequenceRange",
+          "rangeStart": 106,
+          "rangeEnd": 143
+        },
+        "additionalProperty": {
+          "@type": "PropertyValue",
+          "name": "Term",
+          "value": {
+            "@type": "DefinedTerm",
+            "@id": "https://www.disprot.org/assets/data/idpontology_disprot_8_v0.1.0.owl#DO:00076", ???
+            "inDefinedTermSet": {
+              "@type": "DefinedTermSet",
+              "@id": "https://www.disprot.org/assets/data/idpontology_disprot_8_v0.1.0.owl", ???
+              "name": "TR ontology"
+            },
+            "termCode": "DO:00076", ???
+            "name": "Repeat unit" alternative: Repeat insertion
+          }
+        },
+        "description": "Repeat structure for the protein"
+      }
+    ]
+  }
+}

--- a/Dataset/examples/0.3-DRAFT_examples/DisProt_jsonld.json
+++ b/Dataset/examples/0.3-DRAFT_examples/DisProt_jsonld.json
@@ -1,1 +1,0 @@
-../../../DataCatalog/examples/0.3-DRAFT/DisProt_jsonld.json

--- a/Protein/examples/0.9-DRAFT/DisProt_jsonld.json
+++ b/Protein/examples/0.9-DRAFT/DisProt_jsonld.json
@@ -1,1 +1,0 @@
-../../../DataRecord/examples/0.2-DRAFT_examples/DisProt_jsonld.json

--- a/SequenceAnnotation/examples/0.1-DRAFT/DisProt_jsonld.json
+++ b/SequenceAnnotation/examples/0.1-DRAFT/DisProt_jsonld.json
@@ -1,1 +1,0 @@
-../../../DataRecord/examples/0.2-DRAFT_examples/DisProt_jsonld.json

--- a/SequenceRange/examples/0.1-DRAFT/DisProt_jsonld.json
+++ b/SequenceRange/examples/0.1-DRAFT/DisProt_jsonld.json
@@ -1,1 +1,0 @@
-../../../DataRecord/examples/0.2-DRAFT_examples/DisProt_jsonld.json


### PR DESCRIPTION
Add MobiDB exmaples for DataCatalog (includes Dataset) and DataRecord (includes Protein, SequenceAnnotation, SequenceRange). Remove broken symlinks from DisProt examples