### PR TITLE
Update LabProtocol_v0.4-DRAFT.jsonld

### DIFF
--- a/LabProtocol/jsonld/type/LabProtocol_v0.4-DRAFT.jsonld
+++ b/LabProtocol/jsonld/type/LabProtocol_v0.4-DRAFT.jsonld
@@ -117,7 +117,36 @@
         }
       ]
     },
+    {
+      "@id": "bioschemastypesdrafts:bioSample",
+      "@type": "rdf:Property",
+      "rdfs:comment": "BioSample used in the protocol. It could be a record in a Dataset describing the sample or a physical object corresponding to the sample or a URL pointing to the type of sample used.",
+      "rdfs:label": "bioSample",
+      "schema:domainIncludes": {
+	    "@id": "bioschemastypesdrafts:LabProtocol"
+	  },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:BioChemEntity"
+        },
 	{
+          "@id": "bioschemastypes:BioSample"
+        },
+	{
+          "@id": "schema:DefinedTerm"
+        },
+	{
+          "@id": "schema:Taxon"
+        },
+	{
+          "@id": "schema:Text"
+        },
+	{
+          "@id": "schema:URL"
+        }      
+      ]
+    },
+    {
       "@id": "bioschemastypesdrafts:labEquipment",
       "@type": "rdf:Property",
       "rdfs:comment": "A laboratory equipment used by a person to follow one or more steps described in this LabProtocol.",
@@ -174,8 +203,25 @@
     {
       "@id": "bioschemastypesdrafts:protocolLimitation",
       "@type": "rdf:Property",
-      "rdfs:comment": "Situations where the Protocol would be unreliable or otherwise unsuccessful",
+      "rdfs:comment": "Situations where the Protocol would be unreliable or otherwise unsuccessful.",
       "rdfs:label": "protocolLimitation",
+      "schema:domainIncludes": [
+	    {"@id": "bioschemastypesdrafts:LabProtocol"}
+	  ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:CreativeWork"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemastypesdrafts:protocolOutcome",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Actual outcome or result by a protocol execution. The shape of the expected outcome/result can be described using the property 'output'.",
+      "rdfs:label": "protocolOutcome",
       "schema:domainIncludes": [
 	    {"@id": "bioschemastypesdrafts:LabProtocol"}
 	  ],
@@ -200,8 +246,14 @@
         {
           "@id": "schema:BioChemEntity"
         },
+	{
+          "@id": "schema:ChemicalSubstance"
+        },
         {
           "@id": "schema:DefinedTerm"
+        },
+	{
+          "@id": "schema:MolecularEntity"
         },
         {
           "@id": "schema:Text"


### PR DESCRIPTION
Add missing information that I noticed when creating the profile.

## Internal reference


## Description
Reintroduces some properties and expected types needed for the profile, see https://bioschemas.org/profiles/LabProtocol/0.7-DRAFT

## Motivation and context
Make it easier to create the profile

## Have these been tested?


## What should reviewers focus on?
Valid against DDE

## Types of changes
Two re-introduced property (protocolOutcome, bioSample --we now know it will be kept as a type) and additional expected types for reagent.

## Future TO-DOs
Create the profile and ask for community feedback
