### PR TITLE
Correct type from Taxon to TaxonName

### DIFF
--- a/TaxonName/README.md
+++ b/TaxonName/README.md
@@ -2,7 +2,7 @@
 
 ## Type 
 
-Thing > [Taxon](https://bioschemas.org/Taxon/)
+Thing > CreativeWork > [TaxonName](https://bioschemas.org/TaxonName/)
 
 ## Profile
 


### PR DESCRIPTION
## Internal reference
None

## Description
Specification of TaxonName appears to have been copy-pasted from Taxon specification. Have changed the Type to match release: https://bioschemas.org/types/TaxonName/1.0-RELEASE

## Motivation and context
I was browsing the specification files on GitHub and spotted a mistake.

## Have these been tested?
No

## What should reviewers focus on?
I don't know what implication this mistake has, might be negligible.

## Types of changes
Unknown

## Future TO-DOs
None
