### PR TITLE
Fix DDE tutorial link in readme.md

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -1,6 +1,6 @@
 # Steps to Render a Bioschemas Profile on the Bioschema Website
 
-It is assumed that you have already made the edits to the profile (see this [tutorial](/tutorials/dde/) for details on how to edit a profile), stored it in the [Bioschemas Specification repository](https://github.com/BioSchemas/specifications), and that you are now ready to get it published on the Bioschemas website.
+It is assumed that you have already made the edits to the profile (see this [tutorial](https://bioschemas.org/tutorials/dde/) for details on how to edit a profile), stored it in the [Bioschemas Specification repository](https://github.com/BioSchemas/specifications), and that you are now ready to get it published on the Bioschemas website.
 
 ## 1. Manual Configuration in the Website Repository
 For new profiles:


### PR DESCRIPTION
Updated the DDE tutorial link to point to the correct URL.

## Description
- The first link in the Specifications readme pointed to the old DDE tutorials (part of the specifications GitHub repo `/tutorials/` which no longer exists. 
- Replaced with link to DDE tutorials on the Bioschemas website. (Please confirm this is the correct destination.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change which adds new content)
- [ ] Modified content (non-breaking change which modifies existing content)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
